### PR TITLE
upgrade system to ESP 32 board and stepper motor

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,10 @@
 {
-	// See http://go.microsoft.com/fwlink/?LinkId=827846
-	// for the documentation about the extensions.json format
-	"recommendations": [
-		"platformio.platformio-ide"
-	]
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
 }

--- a/lib/Config/Config.sample.h
+++ b/lib/Config/Config.sample.h
@@ -6,32 +6,19 @@
 #define HOSTNAME "smart-blinds"
 
 /**
- * Seconds it takes to open/close your blinds
+ * Number of revolutions it takes to open/close your blinds
  */
-#define DEFAULT_SECONDS_TO_CLOSE 10
-#define DEFAULT_SECONDS_TO_OPEN 15
+#define TOTAL_ROTATIONS 10
 
 /**
- * Servo Reset Settings
- * 
- * MG 995/6 servos stop spinning after 14 seconds
- * and need a 150ms "break" before we can use again
- * 
- * Set SERVO_RESET_REQUIRED to true if your servo requires this
+ * Speed to open and close blinds
+ * Set as a delay between steps in microseconds
  */
-#define SERVO_RESET_REQUIRED false
-#define SERVO_RESET_EVERY_SECONDS 14
-#define SERVO_RESET_DELAY_MILLISECONDS 150
+#define STEPS_DELAY_FAST 600
+#define STEPS_DELAY_SLOW 900
 
 /**
- * Servo Stop Settings
- * 
- * DS 3218/3225 MG servos keep spinning after detatching
- * Need to set duty cycle to zero point (usually 90)
- * for a few ms for it stop spinning
- * 
- * Set SERVO_STOP_SIGNAL_REQUIRED to true if your servo requires this
+ * Time it takes to fully open/close blinds
+ * Set as a maximum time in seconds
  */
-#define SERVO_STOP_SIGNAL_REQUIRED false
-#define SERVO_STOP_DUTYCYCLE 90
-#define SERVO_STOP_SIGNAL_MILLISECONDS 50
+#define MAX_SPIN_TIME 180

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,12 +14,22 @@ board = nodemcuv2
 framework = arduino
 
 ; any port that starts with /dev/ttyUSB
-upload_port = /dev/cu.SLAB_USBtoUART
+upload_port = /dev/cu.usbserial-0001
 
 ; Custom Serial Monitor speed (baud rate)
 monitor_speed = 115200
 
 ; Async Web Server library
 ; https://github.com/me-no-dev/ESPAsyncWebServer
-lib_deps = ESP Async WebServer
+lib_deps =
+    TMCStepper
+    ESP Async WebServer
+    ; AsyncTCP
+    ; SpeedyStepper
+    EspSoftwareSerial
+    ; SoftwareSerial
+    ; Streaming
+    ; AccelStepper
+    ; FlexyStepper
+    ; SpeedyStepper
 lib_ldf_mode = chain+

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,9 +8,9 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:nodemcuv2]
-platform = espressif8266
-board = nodemcuv2
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
 framework = arduino
 
 ; any port that starts with /dev/ttyUSB

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,17 +19,7 @@ upload_port = /dev/cu.usbserial-0001
 ; Custom Serial Monitor speed (baud rate)
 monitor_speed = 115200
 
-; Async Web Server library
-; https://github.com/me-no-dev/ESPAsyncWebServer
 lib_deps =
     TMCStepper
     ESP Async WebServer
-    ; AsyncTCP
-    ; SpeedyStepper
-    EspSoftwareSerial
-    ; SoftwareSerial
-    ; Streaming
-    ; AccelStepper
-    ; FlexyStepper
-    ; SpeedyStepper
 lib_ldf_mode = chain+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,11 @@
  * Powered by a TMC2209 stepper driver
  */
 
+#include <EEPROM.h>
 #include <SoftwareSerial.h>
 #include <TMCStepper.h>
+#include <ESPAsyncWebServer.h>
+#include <Config.h>
 
 #define LED_ESP_PIN 2
 #define LED_MCU_PIN 16
@@ -20,33 +23,47 @@
 #define DRIVER_ADDRESS  0b00  // TMC2209 Driver address according to MS1 and MS2
 #define R_SENSE         0.11f // SilentStepStick series use 0.11
 
-#define STEP_DELAY    1000  // delay between steps in microseconds
+#define STEP_DELAY    2000  // delay between steps in microseconds
 #define STEPS_PER_REV 1600  // number of steps per revolution
 #define MOTOR_CURRENT 2800  // motor current in milliamps
-#define MICROSTEPS    8     // microsteps per step
-#define MAX_CONTINUOUS_STEPS  STEPS_PER_REV/2
+#define MICROSTEPS    256   // microsteps per step
+#define MAX_CONTINUOUS_STEPS  STEPS_PER_REV/4
 
 #define SERIAL_BAUD_RATE    115200
 #define SW_SERIAL_BAUD_RATE 19200
 
 SoftwareSerial SWSerial(SW_RX, SW_TX);
-
 TMC2209Stepper driver(&SWSerial, R_SENSE, DRIVER_ADDRESS);
+AsyncWebServer server(80);
+
+// blinds settings
+unsigned int totalSteps = STEPS_PER_REV * TOTAL_ROTATIONS;
+
+// blind position / state vars
+double startingPosition = 0;
+double currentPosition = 0;
+double desiredPosition = 0;
+bool spinning = false;
+int direction; // 1 is closing, -1 is opening
 
 void moveStepper(int steps, int dir) {
   int currentSteps = min(steps, MAX_CONTINUOUS_STEPS);
   Serial.print("moving ");
   Serial.println(currentSteps);
 
+  digitalWrite(LED_ESP_PIN, LOW); // turn on esp light
   digitalWrite(EN_PIN, LOW); // enable stepper motor driver
   digitalWrite(DIR_PIN, dir);
   for (int i = 0; i < currentSteps; i++) {
     digitalWrite(STEP_PIN, HIGH);
+    // yield();
     delayMicroseconds(STEP_DELAY);
     digitalWrite(STEP_PIN, LOW);
+    // yield();
     delayMicroseconds(STEP_DELAY);
   }
   digitalWrite(EN_PIN, HIGH); // disable stepper motor driver
+  digitalWrite(LED_ESP_PIN, HIGH); // turn off esp light
 
   int additionalSteps = steps - currentSteps;
   Serial.print("remaining steps: ");
@@ -54,6 +71,17 @@ void moveStepper(int steps, int dir) {
   if (additionalSteps > 0) {
     moveStepper(additionalSteps, dir);
   }
+}
+
+void runServer() {
+  // get position
+  server.on("/position", HTTP_GET, [] (AsyncWebServerRequest *request) {
+    digitalWrite(LED_MCU_PIN, LOW);
+    request->send(200, "text/plain", String(currentPosition));
+    digitalWrite(LED_MCU_PIN, HIGH);
+  });
+
+  server.begin();
 }
 
 void setup() {
@@ -69,6 +97,10 @@ void setup() {
   pinMode(DIR_PIN, OUTPUT);
   pinMode(LED_ESP_PIN, OUTPUT);
   pinMode(LED_MCU_PIN, OUTPUT);
+
+  // Turn off lights
+  digitalWrite(LED_ESP_PIN, HIGH);
+  digitalWrite(LED_MCU_PIN, HIGH);
 
   // Enable driver
   digitalWrite(EN_PIN, LOW);
@@ -86,8 +118,22 @@ void setup() {
 
   // use stealthChop for quiet operation
   driver.toff(3);
-  driver.en_spreadCycle(false);
+  driver.en_spreadCycle(true);
   driver.pwm_autoscale(true);
+
+  // wifi connect
+  WiFi.mode(WIFI_STA);
+  WiFi.hostname(HOSTNAME);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  if (WiFi.waitForConnectResult() != WL_CONNECTED) {
+    Serial.println("WiFi Failed!");
+    return;
+  }
+
+  Serial.print("IP Address: ");
+  Serial.println(WiFi.localIP());
+
+  runServer();
 }
 
 void loop() {
@@ -96,14 +142,18 @@ void loop() {
   Serial.println(msread);
 
   Serial.println("spin forward");
-  digitalWrite(LED_ESP_PIN, HIGH);  // turn off esp light
+  digitalWrite(LED_ESP_PIN, LOW);  // turn on esp light
   digitalWrite(LED_MCU_PIN, LOW);   // turn on mcu light
+  digitalWrite(EN_PIN, LOW);
   moveStepper(STEPS_PER_REV*3, 1);
-  delay(1000); // pause for a second
+  digitalWrite(EN_PIN, HIGH);
+  delay(5000); // pause for a second
 
   Serial.println("spin backward");
   digitalWrite(LED_ESP_PIN, LOW);   // turn on esp light
   digitalWrite(LED_MCU_PIN, HIGH);  // turn off light
+  digitalWrite(EN_PIN, LOW);
   moveStepper(STEPS_PER_REV*3, 0);
-  delay(1000); // pause for a second
+  digitalWrite(EN_PIN, HIGH);
+  delay(5000); // pause for a second
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,30 +21,39 @@
 #define R_SENSE         0.11f // SilentStepStick series use 0.11
 
 #define STEP_DELAY    1000  // delay between steps in microseconds
-#define STEPS_PER_REV 900   // number of steps per revolution
+#define STEPS_PER_REV 1600  // number of steps per revolution
 #define MOTOR_CURRENT 2800  // motor current in milliamps
 #define MICROSTEPS    8     // microsteps per step
+#define MAX_CONTINUOUS_STEPS  STEPS_PER_REV/2
 
 #define SERIAL_BAUD_RATE    115200
-#define SW_SERIAL_BAUD_RATE 9600
+#define SW_SERIAL_BAUD_RATE 19200
 
 SoftwareSerial SWSerial(SW_RX, SW_TX);
 
 TMC2209Stepper driver(&SWSerial, R_SENSE, DRIVER_ADDRESS);
 
-// spin direction
-bool dir = false;
-
 void moveStepper(int steps, int dir) {
+  int currentSteps = min(steps, MAX_CONTINUOUS_STEPS);
+  Serial.print("moving ");
+  Serial.println(currentSteps);
+
   digitalWrite(EN_PIN, LOW); // enable stepper motor driver
   digitalWrite(DIR_PIN, dir);
-  for (int i = 0; i < steps; i++) {
+  for (int i = 0; i < currentSteps; i++) {
     digitalWrite(STEP_PIN, HIGH);
     delayMicroseconds(STEP_DELAY);
     digitalWrite(STEP_PIN, LOW);
     delayMicroseconds(STEP_DELAY);
   }
   digitalWrite(EN_PIN, HIGH); // disable stepper motor driver
+
+  int additionalSteps = steps - currentSteps;
+  Serial.print("remaining steps: ");
+  Serial.println(additionalSteps);
+  if (additionalSteps > 0) {
+    moveStepper(additionalSteps, dir);
+  }
 }
 
 void setup() {
@@ -61,34 +70,40 @@ void setup() {
   pinMode(LED_ESP_PIN, OUTPUT);
   pinMode(LED_MCU_PIN, OUTPUT);
 
-  // Enable driver board
+  // Enable driver
   digitalWrite(EN_PIN, LOW);
 
   driver.begin();
-  driver.rms_current(MOTOR_CURRENT); // Set motor RMS current
-  driver.microsteps(MICROSTEPS);     // Set microsteps
+  driver.rms_current(MOTOR_CURRENT);  // set motor RMS current
+  driver.microsteps(MICROSTEPS);      // set microsteps
+  driver.blank_time(24);              // driver blanking time
+  driver.irun(31);                    // motor run current
+  driver.TCOOLTHRS(0xFFFFF);          // coolstep threshold
+  driver.SGTHRS(255);                 // stallguard threshold
 
   Serial.print("current set to:");
   Serial.println(driver.rms_current());
 
   // use stealthChop for quiet operation
   driver.toff(3);
-  driver.en_spreadCycle(true);
+  driver.en_spreadCycle(false);
   driver.pwm_autoscale(true);
 }
 
 void loop() {
+  uint16_t msread=driver.microsteps();
+  Serial.print(F("Read microsteps via UART to test UART receive : "));
+  Serial.println(msread);
+
   Serial.println("spin forward");
   digitalWrite(LED_ESP_PIN, HIGH);  // turn off esp light
   digitalWrite(LED_MCU_PIN, LOW);   // turn on mcu light
-  moveStepper(STEPS_PER_REV, 1);
-
+  moveStepper(STEPS_PER_REV*3, 1);
   delay(1000); // pause for a second
 
   Serial.println("spin backward");
   digitalWrite(LED_ESP_PIN, LOW);   // turn on esp light
   digitalWrite(LED_MCU_PIN, HIGH);  // turn off light
-  moveStepper(STEPS_PER_REV, 0);
-
+  moveStepper(STEPS_PER_REV*3, 0);
   delay(1000); // pause for a second
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,39 +1,36 @@
 /**
- * ESP 8266 smart blinds
+ * ESP32 smart blinds
  * Using a stepper motor
  * Powered by a TMC2209 stepper driver
  */
 
 #include <EEPROM.h>
-#include <SoftwareSerial.h>
 #include <TMCStepper.h>
 #include <ESPAsyncWebServer.h>
 #include <Config.h>
 
-#define LED_ESP_PIN 2
-#define LED_MCU_PIN 16
+#define LED_PIN 2
 
-#define EN_PIN    14  // Driver enable pin
-#define DIR_PIN   4   // Driver direction pin
-#define STEP_PIN  5   // Driver step pin
+#define SERIAL_PORT Serial2
 
-#define SW_SCK          5     // Clock
-#define SW_TX           9     // Serial receive pin
-#define SW_RX           10    // Serial transmit pin
+#define EN_PIN    25  // Driver enable pin
+#define DIR_PIN   26  // Driver direction pin
+#define STEP_PIN  27  // Driver step pin
+
+#define CLK             14    // Clock
 #define DRIVER_ADDRESS  0b00  // TMC2209 Driver address according to MS1 and MS2
 #define R_SENSE         0.11f // SilentStepStick series use 0.11
 
-#define STEP_DELAY    2000  // delay between steps in microseconds
+#define STEPS_DELAY_FAST  750   // delay between steps in microseconds
+#define STEPS_DELAY_SLOW  1000  // delay between steps in microseconds
+
 #define STEPS_PER_REV 1600  // number of steps per revolution
 #define MOTOR_CURRENT 2800  // motor current in milliamps
 #define MICROSTEPS    256   // microsteps per step
-#define MAX_CONTINUOUS_STEPS  STEPS_PER_REV/4
 
 #define SERIAL_BAUD_RATE    115200
-#define SW_SERIAL_BAUD_RATE 19200
 
-SoftwareSerial SWSerial(SW_RX, SW_TX);
-TMC2209Stepper driver(&SWSerial, R_SENSE, DRIVER_ADDRESS);
+TMC2209Stepper driver(&SERIAL_PORT, R_SENSE, DRIVER_ADDRESS);
 AsyncWebServer server(80);
 
 // blinds settings
@@ -47,47 +44,37 @@ bool spinning = false;
 int direction; // 1 is closing, -1 is opening
 
 void moveStepper(int steps, int dir) {
-  int currentSteps = min(steps, MAX_CONTINUOUS_STEPS);
+  digitalWrite(LED_PIN, HIGH); // turn on light
   Serial.print("moving ");
-  Serial.println(currentSteps);
+  Serial.println(steps);
 
-  digitalWrite(LED_ESP_PIN, LOW); // turn on esp light
+  int stepsDelay = dir ? STEPS_DELAY_FAST : STEPS_DELAY_SLOW;
+
   digitalWrite(EN_PIN, LOW); // enable stepper motor driver
   digitalWrite(DIR_PIN, dir);
-  for (int i = 0; i < currentSteps; i++) {
+  for (int i = 0; i < steps; i++) {
     digitalWrite(STEP_PIN, HIGH);
-    // yield();
-    delayMicroseconds(STEP_DELAY);
+    delayMicroseconds(stepsDelay);
     digitalWrite(STEP_PIN, LOW);
-    // yield();
-    delayMicroseconds(STEP_DELAY);
+    delayMicroseconds(stepsDelay);
   }
   digitalWrite(EN_PIN, HIGH); // disable stepper motor driver
-  digitalWrite(LED_ESP_PIN, HIGH); // turn off esp light
-
-  int additionalSteps = steps - currentSteps;
-  Serial.print("remaining steps: ");
-  Serial.println(additionalSteps);
-  if (additionalSteps > 0) {
-    moveStepper(additionalSteps, dir);
-  }
+  digitalWrite(LED_PIN, LOW); // turn off light
 }
 
 void runServer() {
   // get position
   server.on("/position", HTTP_GET, [] (AsyncWebServerRequest *request) {
-    digitalWrite(LED_MCU_PIN, LOW);
     request->send(200, "text/plain", String(currentPosition));
-    digitalWrite(LED_MCU_PIN, HIGH);
   });
 
   server.begin();
 }
 
 void setup() {
-  Serial.begin(SERIAL_BAUD_RATE);           // initialize hardware serial for logging
-  SWSerial.begin(SW_SERIAL_BAUD_RATE);      // initialize software serial for UART motor control
-  driver.beginSerial(SW_SERIAL_BAUD_RATE);  // Initialize driver over UART
+  Serial.begin(SERIAL_BAUD_RATE);           // initialize serial0 for logging
+  Serial2.begin(SERIAL_BAUD_RATE);          // initialize serial2 for UART motor control
+  driver.begin();                           // Initialize driver over UART
 
   Serial.println("init start");
   
@@ -95,12 +82,10 @@ void setup() {
   pinMode(EN_PIN, OUTPUT);
   pinMode(STEP_PIN, OUTPUT);
   pinMode(DIR_PIN, OUTPUT);
-  pinMode(LED_ESP_PIN, OUTPUT);
-  pinMode(LED_MCU_PIN, OUTPUT);
+  pinMode(LED_PIN, OUTPUT);
 
   // Turn off lights
-  digitalWrite(LED_ESP_PIN, HIGH);
-  digitalWrite(LED_MCU_PIN, HIGH);
+  digitalWrite(LED_PIN, LOW);
 
   // Enable driver
   digitalWrite(EN_PIN, LOW);
@@ -137,23 +122,19 @@ void setup() {
 }
 
 void loop() {
-  uint16_t msread=driver.microsteps();
+  uint16_t msread = driver.microsteps();
   Serial.print(F("Read microsteps via UART to test UART receive : "));
   Serial.println(msread);
 
-  Serial.println("spin forward");
-  digitalWrite(LED_ESP_PIN, LOW);  // turn on esp light
-  digitalWrite(LED_MCU_PIN, LOW);   // turn on mcu light
+  Serial.println("spin forward - closing"); // closing
   digitalWrite(EN_PIN, LOW);
   moveStepper(STEPS_PER_REV*3, 1);
   digitalWrite(EN_PIN, HIGH);
-  delay(5000); // pause for a second
+  delay(2000); // pause for 2s
 
-  Serial.println("spin backward");
-  digitalWrite(LED_ESP_PIN, LOW);   // turn on esp light
-  digitalWrite(LED_MCU_PIN, HIGH);  // turn off light
+  Serial.println("spin backward - opening"); // opening
   digitalWrite(EN_PIN, LOW);
   moveStepper(STEPS_PER_REV*3, 0);
   digitalWrite(EN_PIN, HIGH);
-  delay(5000); // pause for a second
+  delay(2000); // pause for 2s
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@
 
 TMC2209Stepper driver(&SERIAL_PORT, R_SENSE, DRIVER_ADDRESS);
 AsyncWebServer server(80);
-TaskHandle_t MoveStepperTask;
+TaskHandle_t moveStepperTask;
 
 // blinds settings
 unsigned int totalSteps = STEPS_PER_REV * TOTAL_ROTATIONS;
@@ -105,9 +105,9 @@ void runServer() {
       Serial.println(desiredPosition);
 
       // stop any running tasks
-      if (MoveStepperTask != NULL) {
-        vTaskDelete(MoveStepperTask);
-        MoveStepperTask = NULL;
+      if (moving) {
+        vTaskDelete(moveStepperTask);
+        moveStepperTask = NULL;
       }
 
       esp_task_wdt_init(60, false);
@@ -117,7 +117,7 @@ void runServer() {
         10000,                // Stack size
         NULL,                 // Parameters
         1,                    // Priority
-        &MoveStepperTask,     // Task handle
+        &moveStepperTask,     // Task handle
         0                     // Core number
       );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,27 +4,33 @@
  * Powered by a TMC2209 stepper driver
  */
 
-#include <Arduino.h>
+#include <SoftwareSerial.h>
 #include <TMCStepper.h>
-#include <AccelStepper.h>
 
 #define LED_ESP_PIN 2
 #define LED_MCU_PIN 16
 
-#define EN_PIN    10  // Driver enable pin
-#define DIR_PIN   4   // Driver irection pin
+#define EN_PIN    14  // Driver enable pin
+#define DIR_PIN   4   // Driver direction pin
 #define STEP_PIN  5   // Driver step pin
 
 #define SW_SCK          5     // Clock
-#define SW_TX           1     // Serial receive pin
-#define SW_RX           3     // Serial transmit pin
+#define SW_TX           9     // Serial receive pin
+#define SW_RX           10    // Serial transmit pin
 #define DRIVER_ADDRESS  0b00  // TMC2209 Driver address according to MS1 and MS2
 #define R_SENSE         0.11f // SilentStepStick series use 0.11
 
 #define STEP_DELAY    1000  // delay between steps in microseconds
 #define STEPS_PER_REV 900   // number of steps per revolution
+#define MOTOR_CURRENT 2800  // motor current in milliamps
+#define MICROSTEPS    8     // microsteps per step
 
-TMC2209Stepper driver(&Serial, R_SENSE, DRIVER_ADDRESS);
+#define SERIAL_BAUD_RATE    115200
+#define SW_SERIAL_BAUD_RATE 9600
+
+SoftwareSerial SWSerial(SW_RX, SW_TX);
+
+TMC2209Stepper driver(&SWSerial, R_SENSE, DRIVER_ADDRESS);
 
 // spin direction
 bool dir = false;
@@ -42,8 +48,11 @@ void moveStepper(int steps, int dir) {
 }
 
 void setup() {
-  Serial.begin(115200);         // initialize hardware serial for UART motor control
-  driver.beginSerial(115200);   // Initialize UART
+  Serial.begin(SERIAL_BAUD_RATE);           // initialize hardware serial for logging
+  SWSerial.begin(SW_SERIAL_BAUD_RATE);      // initialize software serial for UART motor control
+  driver.beginSerial(SW_SERIAL_BAUD_RATE);  // Initialize driver over UART
+
+  Serial.println("init start");
   
   // Set pinmodes
   pinMode(EN_PIN, OUTPUT);
@@ -56,22 +65,27 @@ void setup() {
   digitalWrite(EN_PIN, LOW);
 
   driver.begin();
-  driver.rms_current(2800); // Set motor RMS current
-  driver.microsteps(0);     // Set microsteps
+  driver.rms_current(MOTOR_CURRENT); // Set motor RMS current
+  driver.microsteps(MICROSTEPS);     // Set microsteps
+
+  Serial.print("current set to:");
+  Serial.println(driver.rms_current());
 
   // use stealthChop for quiet operation
   driver.toff(3);
-  driver.en_spreadCycle(false);
+  driver.en_spreadCycle(true);
   driver.pwm_autoscale(true);
 }
 
 void loop() {
+  Serial.println("spin forward");
   digitalWrite(LED_ESP_PIN, HIGH);  // turn off esp light
   digitalWrite(LED_MCU_PIN, LOW);   // turn on mcu light
   moveStepper(STEPS_PER_REV, 1);
 
   delay(1000); // pause for a second
 
+  Serial.println("spin backward");
   digitalWrite(LED_ESP_PIN, LOW);   // turn on esp light
   digitalWrite(LED_MCU_PIN, HIGH);  // turn off light
   moveStepper(STEPS_PER_REV, 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,263 +1,80 @@
 /**
- * Blinds
- *
  * ESP 8266 smart blinds
+ * Using a stepper motor
+ * Powered by a TMC2209 stepper driver
  */
 
 #include <Arduino.h>
-#include <Servo.h>
-#include <EEPROM.h>
-#include <ESPAsyncWebServer.h>
-#include <Config.h>
+#include <TMCStepper.h>
+#include <AccelStepper.h>
 
 #define LED_ESP_PIN 2
 #define LED_MCU_PIN 16
-#define RELAY_PIN 5
-#define SERVO_PIN 4
 
-AsyncWebServer server(80);
-Servo servo;
+#define EN_PIN    10  // Driver enable pin
+#define DIR_PIN   4   // Driver irection pin
+#define STEP_PIN  5   // Driver step pin
 
-// addresses of data stored in EEPROM
-struct {
-  int initialized = 0;
-  int secondsToClose = sizeof(bool);
-  int secondsToOpen = sizeof(bool) + sizeof(float);
-  int currentPosition = sizeof(bool) + (sizeof(float) * 2);
-} eepromAddresses;
+#define SW_SCK          5     // Clock
+#define SW_TX           1     // Serial receive pin
+#define SW_RX           3     // Serial transmit pin
+#define DRIVER_ADDRESS  0b00  // TMC2209 Driver address according to MS1 and MS2
+#define R_SENSE         0.11f // SilentStepStick series use 0.11
 
-// default timing settings
-float secondsToClose = DEFAULT_SECONDS_TO_CLOSE;
-float secondsToOpen = DEFAULT_SECONDS_TO_OPEN;
-unsigned int milliesPerPercentClose = (secondsToClose * 1000) / 100;
-unsigned int millisPerPercentOpen = (secondsToOpen * 1000) / 100;
+#define STEP_DELAY    1000  // delay between steps in microseconds
+#define STEPS_PER_REV 900   // number of steps per revolution
 
-// milliseconds of spinning, after which the servo has to be reset
-const unsigned int millisPerServoReset = (SERVO_RESET_EVERY_SECONDS * 1000);
+TMC2209Stepper driver(&Serial, R_SENSE, DRIVER_ADDRESS);
 
-// blind position / state vars
-double startingPosition = 0;
-double currentPosition = 0;
-double desiredPosition = 0;
-bool spinning = false;
-int direction; // 1 is closing, -1 is opening
-int dutyCycle = 90; // 0 is counter-clockwise, 180 is clockwise
+// spin direction
+bool dir = false;
 
-// stores the last time a cycle was initiated
-unsigned long previousMillis = 0;
-
-// stores the last time servo was reset
-unsigned long lastResetMillis = 0;
-
-// calculated interval (ms) of spin cycle
-long interval = 0;
-
-void startSpinning(double newPosition){
-  if (newPosition != desiredPosition || newPosition != currentPosition) {
-    if (spinning) {
-      // detach from servo before spinning again
-      servo.detach();
-    }
-
-    desiredPosition = newPosition;
-
-    unsigned long currentMillis = millis();
-
-    Serial.print("current position: ");
-    Serial.println(currentPosition);
-    Serial.print("desired position: ");
-    Serial.println(desiredPosition);
-
-    // calculate spin cycle length (ms)
-    unsigned int millisPerPercent = desiredPosition > currentPosition ? millisPerPercentOpen : milliesPerPercentClose;
-    interval = (long)(abs(desiredPosition - currentPosition) * millisPerPercent);
-    Serial.print("calculated interval: ");
-    Serial.println(interval);
-
-    // turn on relay_PIN
-    digitalWrite(RELAY_PIN, HIGH);
-
-    // start moving servo in desired direction
-    dutyCycle = desiredPosition > currentPosition ? 0 : 180;
-    servo.attach(SERVO_PIN);
-    servo.write(dutyCycle);
-
-    // set state vars
-    direction = desiredPosition > currentPosition ? 1 : -1;
-    previousMillis = currentMillis;
-    lastResetMillis = previousMillis;
-    spinning = true;
-    startingPosition = currentPosition;
-    Serial.print("calculated direction: ");
-    Serial.println(direction);
-    digitalWrite(LED_ESP_PIN, LOW);
+void moveStepper(int steps, int dir) {
+  digitalWrite(EN_PIN, LOW); // enable stepper motor driver
+  digitalWrite(DIR_PIN, dir);
+  for (int i = 0; i < steps; i++) {
+    digitalWrite(STEP_PIN, HIGH);
+    delayMicroseconds(STEP_DELAY);
+    digitalWrite(STEP_PIN, LOW);
+    delayMicroseconds(STEP_DELAY);
   }
+  digitalWrite(EN_PIN, HIGH); // disable stepper motor driver
 }
 
-void resetServo(){
-  Serial.println("detatching servo");
-  servo.detach();
-  delay(SERVO_RESET_DELAY_MILLISECONDS);
-  Serial.println("re-attatching servo");
-  servo.attach(SERVO_PIN);
-  servo.write(dutyCycle);
-}
-
-void stopSpinning(){
-  if (SERVO_STOP_SIGNAL_REQUIRED){
-    servo.write(SERVO_STOP_DUTYCYCLE);
-    delay(SERVO_STOP_SIGNAL_MILLISECONDS);
-  }
-  servo.detach();
-  digitalWrite(RELAY_PIN, LOW);
-  spinning = false;
-  currentPosition = desiredPosition;
-  EEPROM.put(eepromAddresses.currentPosition, currentPosition);
-  EEPROM.commit();
-  Serial.println("finished spinning!");
-  digitalWrite(LED_ESP_PIN, HIGH);
-}
-
-void runServer(){
-  // get position
-  server.on("/position", HTTP_GET, [] (AsyncWebServerRequest *request) {
-    digitalWrite(LED_MCU_PIN, LOW);
-    request->send(200, "text/plain", String(currentPosition));
-    digitalWrite(LED_MCU_PIN, HIGH);
-  });
-
-  // set position with ?position=N (0 to 100)
-  server.on("/set", HTTP_GET, [] (AsyncWebServerRequest *request) {
-    digitalWrite(LED_MCU_PIN, LOW);
-    if (request->hasParam("position")) {
-      double newPosition = request->getParam("position")->value().toDouble();
-      startSpinning(newPosition);
-    }
-    request->send(204);
-    digitalWrite(LED_MCU_PIN, HIGH);
-  });
-
-  // get state
-  server.on("/state", HTTP_GET, [] (AsyncWebServerRequest *request) {
-    digitalWrite(LED_MCU_PIN, LOW);
-    int state = spinning ? (direction == -1 ? 0 : 1) : 2;
-    request->send(200, "text/plain", String(state));
-    digitalWrite(LED_MCU_PIN, HIGH);
-  });
-
-  // update timing settings with ?secondsToClose=X&secondsToOpen=Y (positive float)
-  server.on("/timing", HTTP_GET, [] (AsyncWebServerRequest *request) {
-    if (currentPosition > 0 && currentPosition < 100) {
-      request->send(409, "text/plain", "Cannot update timing now. Move blinds to fully closed or open position and try again.");
-      return;
-    }
-    if (request->hasParam("secondsToClose")) {
-      secondsToClose = request->getParam("secondsToClose")->value().toFloat();
-      EEPROM.put(eepromAddresses.secondsToClose, secondsToClose);
-      milliesPerPercentClose = (secondsToClose * 1000) / 100;
-    }
-    if (request->hasParam("secondsToOpen")) {
-      secondsToOpen = request->getParam("secondsToOpen")->value().toFloat();
-      EEPROM.put(eepromAddresses.secondsToOpen, secondsToOpen);
-      millisPerPercentOpen = (secondsToOpen * 1000) / 100;
-    }
-    EEPROM.commit();
-    request->send(204);
-  });
-
-  // get timing settings
-  server.on("/settings", HTTP_GET, [] (AsyncWebServerRequest *request) {
-    String response = "Seconds to close: " + String(secondsToClose) + "\nSeconds to open: " + String(secondsToOpen);
-    request->send(200, "text/plain", response);
-  });
-
-  // 404
-  server.onNotFound([](AsyncWebServerRequest *request) {
-    request->send(404);
-  });
-
-  server.begin();
-}
-
-void setup(){
-  Serial.begin(115200);
-  EEPROM.begin(512);
-
-  // stop servo from spinning while turning on
-  servo.detach();
-
-  // initialize LED pins as outputs
+void setup() {
+  Serial.begin(115200);         // initialize hardware serial for UART motor control
+  driver.beginSerial(115200);   // Initialize UART
+  
+  // Set pinmodes
+  pinMode(EN_PIN, OUTPUT);
+  pinMode(STEP_PIN, OUTPUT);
+  pinMode(DIR_PIN, OUTPUT);
   pinMode(LED_ESP_PIN, OUTPUT);
   pinMode(LED_MCU_PIN, OUTPUT);
-  pinMode(RELAY_PIN, OUTPUT);
 
-  digitalWrite(LED_ESP_PIN, HIGH);
-  digitalWrite(LED_MCU_PIN, LOW);
+  // Enable driver board
+  digitalWrite(EN_PIN, LOW);
 
-  // wifi connect
-  WiFi.mode(WIFI_STA);
-  WiFi.hostname(HOSTNAME);
-  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
-  if (WiFi.waitForConnectResult() != WL_CONNECTED) {
-    Serial.println("WiFi Failed!");
-    return;
-  }
+  driver.begin();
+  driver.rms_current(2800); // Set motor RMS current
+  driver.microsteps(0);     // Set microsteps
 
-  Serial.print("IP Address: ");
-  Serial.println(WiFi.localIP());
-
-  // get stored settings or use defaults
-  bool initialized = false;
-  EEPROM.get(eepromAddresses.initialized, initialized);
-  if (initialized) {
-    Serial.println("Using settings & position stored on EEPROM");
-    EEPROM.get(eepromAddresses.secondsToClose, secondsToClose);
-    EEPROM.get(eepromAddresses.secondsToOpen, secondsToOpen);
-    EEPROM.get(eepromAddresses.currentPosition, currentPosition);
-  } else {
-    EEPROM.put(eepromAddresses.initialized, true);
-    EEPROM.put(eepromAddresses.secondsToClose, secondsToClose);
-    EEPROM.put(eepromAddresses.secondsToOpen, secondsToOpen);
-    EEPROM.put(eepromAddresses.currentPosition, currentPosition);
-    EEPROM.commit();
-  }
-
-  // milliseconds of rotation per 1% change in blinds
-  milliesPerPercentClose = (secondsToClose * 1000) / 100;
-  millisPerPercentOpen = (secondsToOpen * 1000) / 100;
-
-  Serial.print("Initial position: ");
-  Serial.println(currentPosition);
-  Serial.print("Seconds to close: ");
-  Serial.println(secondsToClose);
-  Serial.print("Seconds to open: ");
-  Serial.println(secondsToOpen);
-
-  runServer();
-
-  digitalWrite(LED_MCU_PIN, HIGH);
+  // use stealthChop for quiet operation
+  driver.toff(3);
+  driver.en_spreadCycle(false);
+  driver.pwm_autoscale(true);
 }
 
-void loop(){
-  unsigned long currentMillis = millis();
+void loop() {
+  digitalWrite(LED_ESP_PIN, HIGH);  // turn off esp light
+  digitalWrite(LED_MCU_PIN, LOW);   // turn on mcu light
+  moveStepper(STEPS_PER_REV, 1);
 
-  if (spinning){
-    // calculate current position
-    double percentCompleted = ((double)(currentMillis - previousMillis))/((double)interval);
-    currentPosition = (percentCompleted * (desiredPosition-startingPosition)) + startingPosition;
+  delay(1000); // pause for a second
 
-    // if position has been reached or is out of range, stop spinning
-    if (currentPosition == desiredPosition || percentCompleted > 1 || currentPosition < 0 || currentPosition > 100){
-      stopSpinning();
-    }
+  digitalWrite(LED_ESP_PIN, LOW);   // turn on esp light
+  digitalWrite(LED_MCU_PIN, HIGH);  // turn off light
+  moveStepper(STEPS_PER_REV, 0);
 
-    // calculate how long the servo has been spinning for
-    unsigned long spinningMillis = currentMillis - lastResetMillis;
-
-    // reset the servo if we need to
-    if (SERVO_RESET_REQUIRED && spinning && spinningMillis >= millisPerServoReset){
-      resetServo();
-      lastResetMillis = currentMillis;
-    }
-  }
+  delay(1000); // pause for a second
 }


### PR DESCRIPTION
Upgrades system to use a stepper motor for improved accuracy, instead of previous method which used a servo and a timing function
Requires using a TMC 2209 stepper motor driver and a ESP 32 board
The ESP 32 board was needed because it has 2 CPU cores vs the original ESP 8266
The functions to drive the stepper motor are run on core 0 and the web server and other operations are run on core 1